### PR TITLE
Maybe multiples commit would have been betters.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,35 +149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
-name = "dotenv_codegen"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56966279c10e4f8ee8c22123a15ed74e7c8150b658b26c619c53f4a56eb4a8aa"
-dependencies = [
- "dotenv_codegen_implementation",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "dotenv_codegen_implementation"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e737a3522cd45f6adc19b644ce43ef53e1e9045f2d2de425c1f468abd4cf33"
-dependencies = [
- "dotenv",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,10 +663,8 @@ name = "motion_detection"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "dotenv_codegen",
  "image",
  "image-compare",
- "lazy_static",
  "mosquitto-client",
  "reqwest",
  "tokio",
@@ -897,12 +866,6 @@ dependencies = [
  "flate2",
  "miniz_oxide 0.7.1",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2021"
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
-lazy_static = "1.4.0"
 mosquitto-client = "0.1.5"
-dotenv_codegen = "0.15.0"
 bytes = "1"
 image-compare = "0.2"
 image = "0.24"

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -1,11 +1,14 @@
 use image::DynamicImage;
 use image_compare::prelude::*;
 
-pub fn compare(past: &DynamicImage, present: &DynamicImage) -> Result<f64, Box<dyn std::error::Error>> {
+pub fn compare(
+    past: &DynamicImage,
+    present: &DynamicImage,
+) -> Result<f64, Box<dyn std::error::Error>> {
     let distortion = image_compare::gray_similarity_structure(
         &Algorithm::RootMeanSquared,
         &past.to_luma8(),
-        &present.to_luma8()
+        &present.to_luma8(),
     )?;
 
     println!("D: {}", distortion.score);

--- a/src/home.rs
+++ b/src/home.rs
@@ -1,59 +1,13 @@
 use bytes::Bytes;
-use lazy_static::lazy_static;
-use mosquitto_client::{MosqMessage, TopicMatcher};
-use reqwest::{Client, RequestBuilder};
-use tokio::{sync::{RwLock, mpsc::Sender}, runtime::Handle};
-use std::{error::Error, sync::Arc};
+use reqwest::RequestBuilder;
+use std::error::Error;
+use tokio::sync::mpsc::Sender;
 
-type Lock = Arc<RwLock<bool>>;
-
-static HTTP_CGI_HOST: &'static str = dotenv!("HTTP_CGI_HOST");
-static HTTP_CGI_USER: &'static str = dotenv!("HTTP_CGI_USER");
-static HTTP_CGI_PASS: &'static str = dotenv!("HTTP_CGI_PASS");
-pub static ABSENT: bool = false;
-pub static PRESENT: bool = !ABSENT;
-
-lazy_static! {
-    static ref REQ_CAM: RequestBuilder = {
-        Client::new()
-            .get(HTTP_CGI_HOST)
-            .basic_auth(HTTP_CGI_USER, Some(HTTP_CGI_PASS))
-    };
-}
-
-async fn send_image(sender_cam: &Sender<Bytes>) -> Result<(), Box<dyn Error>> {
-    let req = REQ_CAM.try_clone().unwrap();
-    let buf = req.send().await?
-                 .bytes().await?;
+pub async fn send_image(
+    request: RequestBuilder,
+    sender_cam: &Sender<Bytes>,
+) -> Result<(), Box<dyn Error>> {
+    let buf = request.send().await?.bytes().await?;
     sender_cam.send(buf).await?;
     Ok(())
-}
-
-pub async fn if_absent_send_image(lock: &Lock, sender_cam: &Sender<Bytes>) -> Result<(), Box<dyn Error>> {
-    if let Ok(is_locked) = lock.try_read() {
-        if *is_locked == ABSENT {
-            send_image(&sender_cam).await?;
-        }
-    }
-    Ok(())
-}
-
-async fn update_presence(lock: &Lock, message: &str) -> Result<(), Box<dyn Error>> {
-    let mut lock = lock.write().await;
-    if "present" == message {
-        *lock = PRESENT;
-    } else if "absent" == message {
-        *lock = ABSENT;
-    }
-    Ok(())
-}
-
-pub fn callback_update_presence(lock: &Lock, event: &TopicMatcher, message: MosqMessage) {
-    if ! message.retained() && event.matches(&message) {
-        tokio::task::block_in_place(move || {
-            Handle::current().block_on(async move {
-                update_presence(lock, message.text()).await.unwrap();
-            })
-        });
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,74 +1,154 @@
-#[macro_use]
-extern crate dotenv_codegen;
-
-mod home;
 mod compare;
+mod home;
 
-use home::{if_absent_send_image, callback_update_presence, ABSENT};
-use lazy_static::lazy_static;
 use compare::compare;
+use home::send_image;
 use mosquitto_client::{Mosquitto, TopicMatcher};
-use std::{error::Error, thread, time, sync::Arc};
-use tokio::time::{self as TokioTime, Duration as TokioDuration};
-use tokio::sync::{RwLock, mpsc::channel};
+use reqwest::Client;
+use std::fmt::Display;
+use std::{error::Error, thread, time};
 use tokio::runtime::Runtime;
+use tokio::sync::mpsc::channel;
+use tokio::time::{self as TokioTime, Duration as TokioDuration};
 
-static MQTT_NAME: &'static str = dotenv!("MQTT_NAME");
-static MQTT_HOST: &'static str = dotenv!("MQTT_HOST");
-static MQTT_PORT: &'static str = dotenv!("MQTT_PORT");
-static MQTT_SUBSCRIBE: &'static str = dotenv!("MQTT_TOPIC_DOOR");
-static MQTT_PUBLISH: &'static str = dotenv!("MQTT_TOPIC_MOTION");
 static MQTT_INTERVAL: time::Duration = time::Duration::from_secs(1);
 static HTTP_CGI_INTERVAL: TokioDuration = TokioDuration::from_secs(1);
 
-lazy_static! {
-    static ref MQTT: Mosquitto = {
-        let mqtt = Mosquitto::new(MQTT_NAME);
-        let port = MQTT_PORT.parse::<u32>().unwrap();
+#[derive(Debug)]
+enum CameraCommand {
+    Send,
+}
+#[derive(Debug)]
+struct PresenceStateError;
+impl Display for PresenceStateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl Error for PresenceStateError {}
+#[derive(Debug, Clone, Copy)]
+enum PresenceState {
+    Present,
+    Absent,
+}
 
-        mqtt.connect(MQTT_HOST, port).unwrap();
-        mqtt
-    };
+impl Display for PresenceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", <&str>::from(*self))
+    }
+}
+
+impl TryFrom<&str> for PresenceState {
+    type Error = PresenceStateError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let state = match value {
+            "present" => Self::Present,
+            "absent" => Self::Absent,
+            _ => return Err(PresenceStateError),
+        };
+        Ok(state)
+    }
+}
+
+impl From<PresenceState> for &str {
+    fn from(value: PresenceState) -> Self {
+        match value {
+            PresenceState::Present => "present",
+            PresenceState::Absent => "absent",
+        }
+    }
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let rt  = Runtime::new()?;
+    // Leaking is bad. But we want immutable ref for the whole program lifetime.
+    // Also it's data from ENV so it already the program lifetime.
+    let mqtt_name = Box::leak(std::env::var("MQTT_NAME").unwrap().into_boxed_str()) as &'static str;
+    let mqtt_host = Box::leak(std::env::var("MQTT_HOST").unwrap().into_boxed_str()) as &'static str;
+    let mqtt_port = Box::leak(std::env::var("MQTT_PORT").unwrap().into_boxed_str()) as &'static str;
+    let mqtt_subscribe =
+        Box::leak(std::env::var("MQTT_TOPIC_DOOR").unwrap().into_boxed_str()) as &'static str;
+    let mqtt_publish =
+        Box::leak(std::env::var("MQTT_TOPIC_MOTION").unwrap().into_boxed_str()) as &'static str;
 
-    let lock = Arc::new(RwLock::new(ABSENT));
-    let lock_cam = lock.clone();
+    let http_cgi_host =
+        Box::leak(std::env::var("HTTP_CGI_HOST").unwrap().into_boxed_str()) as &'static str;
+    let http_cgi_user =
+        Box::leak(std::env::var("HTTP_CGI_USER").unwrap().into_boxed_str()) as &'static str;
+    let http_cgi_pass =
+        Box::leak(std::env::var("HTTP_CGI_PASS").unwrap().into_boxed_str()) as &'static str;
+    let rt = Runtime::new()?;
 
-    let (sender, mut receiver) = channel(2);
-    let sender_cam = sender.clone();
-    rt.spawn(async move {
-        let mut interval = TokioTime::interval(HTTP_CGI_INTERVAL);
+    let (sender_cam, mut receiver) = channel(2);
 
-        loop {
-            if_absent_send_image(&lock_cam, &sender_cam).await.unwrap();
-            interval.tick().await;
-        }
-    });
+    let mosquitto = {
+        let mqtt = Mosquitto::new(&mqtt_name);
+        let port = mqtt_port.parse::<u32>().unwrap();
+        mqtt.connect(&mqtt_host, port).unwrap();
+        mqtt
+    };
 
-    rt.spawn(async move {
-        let event_leave: TopicMatcher = MQTT.subscribe(MQTT_SUBSCRIBE, 1).unwrap();
-        let mut call = MQTT.callbacks(());
+    let (camera_cmd_tx, mut camera_cmd_rx) = channel::<CameraCommand>(1);
 
-        call.on_message(|_, message| callback_update_presence(&lock, &event_leave, message));
+    let mosquitto_event_leave = mosquitto.clone();
+    // Moskitto sync thread sending on_message blocking message to Async HTTP image send only
+    // if absent message is found.
+    let moskitto_thread = std::thread::spawn(move || {
+        let event_leave: TopicMatcher =
+            mosquitto_event_leave.subscribe(&mqtt_subscribe, 1).unwrap();
+        let mut call = mosquitto_event_leave.callbacks(());
+
+        call.on_message(|_, message| {
+            if !message.retained() && event_leave.matches(&message) {
+                let state = PresenceState::try_from(message.text());
+                match state {
+                    Ok(PresenceState::Absent) => {
+                        camera_cmd_tx.blocking_send(CameraCommand::Send).unwrap()
+                    }
+                    Ok(_) => {}
+                    Err(_) => {}
+                }
+            }
+        });
         loop {
             thread::sleep(MQTT_INTERVAL);
-
-            MQTT.do_loop(-1).unwrap();
+            mosquitto_event_leave.do_loop(-1).unwrap();
         }
     });
 
+    // Tokio task awaiting orders from moskitto sync thread
+    // If a command arrive then issue a HTTP call for the image then send the result to
+    // the main thread
+    let handle_camera_send: tokio::task::JoinHandle<Result<(), ()>> = rt.spawn(async move {
+        let mut interval = TokioTime::interval(HTTP_CGI_INTERVAL);
+
+        while let Some(cmd) = camera_cmd_rx.recv().await {
+            match cmd {
+                CameraCommand::Send => {
+                    let request = Client::new()
+                        .get(http_cgi_host)
+                        .basic_auth(http_cgi_user, Some(http_cgi_pass));
+                    send_image(request, &sender_cam).await.map_err(|_| ())?
+                }
+            }
+            interval.tick().await;
+        }
+        Ok(())
+    });
+
+    // Withing the main thread to the comparison of the image sended by the HTTP tokio task.
     let ref before = receiver.blocking_recv().unwrap();
     let mut before = image::load_from_memory(before)?;
-    while let Some(ref after)  = receiver.blocking_recv() {
+    while let Some(ref after) = receiver.blocking_recv() {
         let after = image::load_from_memory(after)?;
-
         let distortion = compare(&before, &after)?;
-        MQTT.publish(&MQTT_PUBLISH, distortion.to_string().as_bytes(), 1, false)?;
+        mosquitto.publish(&mqtt_publish, distortion.to_string().as_bytes(), 1, false)?;
         before = after;
     }
-    MQTT.disconnect()?;
+
+    // Lets finish them all.
+    moskitto_thread.join().unwrap();
+    mosquitto.disconnect()?;
+    handle_camera_send.abort();
     Ok(())
 }


### PR DESCRIPTION
But You get doc and a fresh nice restart. It compiles but didn't has MQTT and the info to run it so test and see! ;)

- Removed lazy_static and dotEnv because useless.
- Get the whole static thing in order
- Moved all the code in main for a fresh start
- Found a nice usage of Enum's for Presence
- Reworked "command on absence" with a channel size 1 instead of a lock
- Passed Moskitto thing into a sequencial-thread since moskitto is doing sequencial code not async (maybe will need the `.threaded()` https://docs.rs/mosquitto-client/latest/mosquitto_client/struct.Mosquitto.html#method.threaded

About the leak: in this case we just don't care. ENV variable are already living the program lifetime so leaking then taking a ref is just OK.

Feel free to ask anything in review.